### PR TITLE
Make requests version less strict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 future
 networkx>=1.11
-requests==2.20.0
+requests>=2.20.0
 sphinx-rtd-theme
 sphinx
 recommonmark


### PR DESCRIPTION
Follow up on https://github.com/adbharadwaj/graphspace-python/issues/36  Requiring exactly requests 2.20.0 still was not compatible with other packages.